### PR TITLE
The json wsp client breaks on HTTP 100 continue

### DIFF
--- a/jsonwspclient.php
+++ b/jsonwspclient.php
@@ -218,6 +218,11 @@ class JsonWspResponse
 		// Split into header/body
 		$responseParts = explode("\r\n\r\n",$response,2);
 
+        // Remove the 100 continues
+        while($responseParts[0] == 'HTTP/1.1 100 Continue'){
+            $responseParts = explode("\r\n\r\n", $responseParts[1], 2);
+        }
+		
 		// Extract status code and description
 		$codeFirstIndex = strpos($responseParts[0]," ");
 		$codeSecondIndex = strpos($responseParts[0]," ",$codeFirstIndex+1);

--- a/jsonwspclient.php
+++ b/jsonwspclient.php
@@ -218,10 +218,10 @@ class JsonWspResponse
 		// Split into header/body
 		$responseParts = explode("\r\n\r\n",$response,2);
 
-        // Remove the 100 continues
-        while($responseParts[0] == 'HTTP/1.1 100 Continue'){
-            $responseParts = explode("\r\n\r\n", $responseParts[1], 2);
-        }
+		// Remove the 100 continues
+		while($responseParts[0] == 'HTTP/1.1 100 Continue'){
+			$responseParts = explode("\r\n\r\n", $responseParts[1], 2);
+		}
 		
 		// Extract status code and description
 		$codeFirstIndex = strpos($responseParts[0]," ");


### PR DESCRIPTION
I had this issue when using the json wsp client for large requests, in this case uploading a file. The result is a few 100 continues, which cause the response string to be empty.

There are probably more elegant solutions to this than what I made, but this works for me right now.
